### PR TITLE
update 0.2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - wheel
   run:
     - python >=3.6
-    - tinycss2 >=0.1.0,<1.2.1
+    - tinycss2 >=1.1.0,<2.0
     - inflection >0.3.0,<1.0
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,17 +12,17 @@ source:
 build:
   number: 0
   skip: true  # [s390x]
-  #Inflection is not available for s390x platform. https://anaconda.org/main/inflection
-
+  #Building this as a new dependency for spyder , which we don’t support on linux-ppc64le or linux-s390x. Therefore we’re skipping those platforms for this build.
+  skip: true  # [py<37]
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - pbr
     - setuptools
     - wheel
   run:
-    - python >=3.6
+    - python
     - tinycss2 >=1.1.0,<2.0
     - inflection >0.3.0,<1.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 0
   skip: true  # [s390x]
+  #Inflection is not available for s390x platform. https://anaconda.org/main/inflection
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   skip: true  # [s390x]
-  #Building this as a new dependency for spyder , which we don’t support on linux-ppc64le or linux-s390x. Therefore we’re skipping those platforms for this build.
+  # inflection is not available for s390x. qstylizer is built as a new dependency for spyder, which we don’t support on linux-s390x. Therefore we’re skipping this platform for this build.
   skip: true  # [py<37]
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ test:
   imports:
     - qstylizer
     - qstylizer.style
-  require:
+  requires:
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,11 +25,14 @@ requirements:
     - tinycss2 >=1.1.0,<2.0
     - inflection >0.3.0,<1.0
 
-
 test:
   imports:
     - qstylizer
     - qstylizer.style
+  require:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/blambright/qstylizer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  skip: true  # [s390x]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "qstylizer" %}
-{% set version = "0.1.10" %}
+{% set version = "0.2.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,9 @@ package:
 
 source:
   url: https://github.com/blambright/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: a5d561ef757d1751766674fba977e339cb4028b057a350969224403f286c4751
+  sha256: 95f7666929cc34efbbd9e0640a13f507b8ec35ec34a9604017cf96c24f7f9ea6
 
 build:
-  noarch: python
   number: 0
 
 requirements:
@@ -18,9 +17,11 @@ requirements:
     - python >=3.6
     - pip
     - pbr
+    - setuptools
+    - wheel
   run:
     - python >=3.6
-    - tinycss >=0.4,<1.0
+    - tinycss2 >=0.1.0,<1.2.1
     - inflection >0.3.0,<1.0
 
 
@@ -38,7 +39,7 @@ about:
   description: |
     qstylizer is a python package designed to help with the construction of
     PyQt/PySide stylesheets.
-  doc_url: http://qstylizer.readthedocs.io
+  doc_url: https://qstylizer.readthedocs.io
   dev_url: https://github.com/blambright/qstylizer
 
 extra:


### PR DESCRIPTION
# Version Bump to 0.2.2
- Updated version number and sha256
-  Added skip for `Linux-s390x` as its dependency `inflection`, is unavailable for `s390x` builds.